### PR TITLE
Implement UPC scoring pipeline

### DIFF
--- a/supabase/_shared/types.ts
+++ b/supabase/_shared/types.ts
@@ -1,0 +1,58 @@
+export interface Ingredient { name: string; dosage?: string; form?: string; }
+
+export interface SupplementData {
+  product_id:   string;
+  brand:        string;
+  product_name: string;
+  ingredients:  Ingredient[];
+  label_claims?:     string[];
+  certifications?:   string[];
+  warnings?:         string[];
+  reviews?: { positive: number; negative: number };
+}
+
+export interface SimplifiedAIResponse {
+  pid: string;  // product_id
+  t:    number; // Transparency / Label honesty 0-10
+  dose: number; // Clinical dosing / bioavailability 0-10
+  qual: number; // Quality & certifications 0-10
+  risk: number; // Additives & brand risk 0-10
+  highlights: string[]; // 1-3 bullets
+}
+
+export interface ScoreBreakdownDetail { score: number; reasons: string[]; weight: number; }
+
+export interface SupplementScoreBreakdown {
+  ingredient_transparency: ScoreBreakdownDetail;
+  label_accuracy:          ScoreBreakdownDetail;
+  clinical_doses:          ScoreBreakdownDetail;
+  bioavailability:         ScoreBreakdownDetail;
+  third_party_testing:     ScoreBreakdownDetail;
+  manufacturing_standards: ScoreBreakdownDetail;
+  additives_fillers:       ScoreBreakdownDetail;
+  brand_history:           ScoreBreakdownDetail;
+  consumer_sentiment:      ScoreBreakdownDetail;
+}
+
+export interface OverallAssessment {
+  strengths: string[];
+  weaknesses: string[];
+  recommendations: string[];
+  safety_rating: string;
+  efficacy_rating: string;
+  transparency_rating: string;
+}
+
+export interface Source { type: string; source: string; url: string; relevance: string; }
+
+export interface FullSupplementScoreResponse {
+  product_id: string;
+  product_name: string;
+  final_score: number;
+  score_breakdown: SupplementScoreBreakdown;
+  overall_assessment: OverallAssessment;
+  sources: Source[];
+  timestamp: string;
+  confidence_score: number;
+  error?: string;
+}

--- a/supabase/functions/full-score-from-upc/index.ts
+++ b/supabase/functions/full-score-from-upc/index.ts
@@ -1,0 +1,59 @@
+/// <reference lib="deno.ns" />
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import type { SupplementData } from "../../_shared/types.ts";
+
+async function findOfficialWebsite(name: string): Promise<string | null> {
+  const key = Deno.env.get("EXPO_PUBLIC_OPENROUTER_API_KEY");
+  if (!key) return null;
+  const model = Deno.env.get("OPENROUTER_SEARCH_MODEL") ?? "openai/gpt-4o-mini";
+  const prompt = `Return ONLY the official product URL (https://...). If none, return NONE.\n${name}`;
+  const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model,
+      temperature: 0,
+      response_format: { type: "text" },
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+  if (!res.ok) return null;
+  const j = await res.json();
+  const txt = j.choices?.[0]?.message?.content?.trim();
+  if (txt && txt.startsWith("http")) return txt;
+  return null;
+}
+
+serve(async (req) => {
+  const upc = new URL(req.url).searchParams.get("upc");
+  if (!upc) return new Response(JSON.stringify({ error: "missing upc" }), { status: 400, headers: { "Content-Type": "application/json" } });
+
+  const base = new URL(req.url);
+  base.pathname = "/functions/v1/resolve-upc";
+  base.search = `upc=${encodeURIComponent(upc)}`;
+  let r = await fetch(base.toString());
+  if (!r.ok) return new Response(await r.text(), { status: r.status, headers: { "Content-Type": "application/json" } });
+  const data: SupplementData = await r.json();
+
+  const url = await findOfficialWebsite(`${data.brand} ${data.product_name}`);
+  let scraped: string | null = null;
+  if (url) {
+    console.log("Website found:", url);
+    const f = new URL(req.url);
+    f.pathname = "/functions/v1/firecrawl-extract";
+    f.search = `url=${encodeURIComponent(url)}`;
+    const fr = await fetch(f.toString());
+    if (fr.ok) {
+      const fj = await fr.json();
+      scraped = fj.content ?? null;
+    }
+  } else {
+    console.log("No official website found");
+  }
+
+  const s = new URL(req.url);
+  s.pathname = "/functions/v1/score-supplement";
+  const body = JSON.stringify({ data, scraped });
+  r = await fetch(s.toString(), { method: "POST", headers: { "Content-Type": "application/json" }, body });
+  return new Response(await r.text(), { status: r.status, headers: { "Content-Type": "application/json" } });
+});

--- a/supabase/functions/resolve-upc/index.ts
+++ b/supabase/functions/resolve-upc/index.ts
@@ -1,191 +1,137 @@
 /// <reference lib="deno.ns" />
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { getFSAccessToken } from "../_shared/fatsecret.ts";
+import type { SupplementData, Ingredient } from "../../_shared/types.ts";
 
-// The SupplementData interface (same as your scoring function)
-interface Ingredient {
-  name: string;
-  dosage?: string;
-  form?: string;
-}
-
-interface SupplementData {
-  product_id: string;
-  ingredients: Ingredient[];
-  brand: string;
-  product_name: string;
-  label_claims?: string[];
-  certifications?: string[];
-  warnings?: string[];
-  reviews?: { positive: number; negative: number };
-}
-
-async function fetchFromOpenFoodFacts(upc: string): Promise<SupplementData | null> {
-  try {
-    const url = `https://world.openfoodfacts.org/api/v2/product/${upc}.json`;
-    const resp = await fetch(url);
-    if (!resp.ok) {
-        console.error(`OpenFoodFacts API returned status: ${resp.status}`);
-        return null;
-    }
-    const data = await resp.json();
-
-    // OpenFoodFacts sometimes returns a status field for missing codes
-    if (data.status !== 1 || !data.product) {
-        console.warn(`UPC ${upc} not found or incomplete data in OpenFoodFacts.`);
-        return null;
-    }
-
-    // Parse fields into your format (add fallbacks as needed)
-    const product = data.product;
-    return {
-      product_id: product.code ?? upc,
-      ingredients: (product.ingredients_text ? [{name: product.ingredients_text}] : (product.ingredients ?? []).map((ing: any) => ({
-        name: ing.text ?? ing.name ?? "",
-        dosage: undefined, // OFF usually doesn't give dosage, can improve later
-        form: undefined
-      }))),
-      brand: product.brands ?? "Unknown",
-      product_name: product.product_name ?? "Unknown",
-      label_claims: product.labels_tags?.filter((tag: string) => tag.startsWith("en:")).map((tag: string) => tag.replace("en:", "")) ?? [],
-      certifications: [], // OFF doesn't always have this; can scrape from ingredients_analysis_tags if present
-      warnings: [],       // Not usually available
-      reviews: { positive: 0, negative: 0 } // Optionally add better logic
-    };
-  } catch (e) {
-    console.error("Error fetching from OpenFoodFacts:", e);
-    return null;
-  }
-}
-
-// DSLD API Integration
-// Corrected base URL based on your provided sample calls for DSLD API
-const DSLD_API_BASE_URL = "https://api.ods.od.nih.gov/dsld/v9";
+const DSLD_URL = "https://api.ods.od.nih.gov/dsld/v9/search-filter";
 
 async function fetchFromDSLD(upc: string): Promise<SupplementData | null> {
-  // Ensure the environment variable is loaded for local testing if using .env
-  // For Supabase deployment, it should be set via `supabase secrets set`
-  console.log("Attempting to retrieve DSLD_API_KEY...");
-  const dSldApiKey = Deno.env.get('DSLD_API_KEY');
-
-  if (!dSldApiKey) {
-    console.warn("DSLD_API_KEY is not set. Cannot fetch data from DSLD.");
-    return null;
-  }
-
-  const upcWithQuotes = `"${upc}"`;
-  const finalEncodedUpc = encodeURIComponent(upcWithQuotes);
-
-  // FIX 1: Changed ?barcode= back to ?q= as per DSLD documentation and successful direct curl
-  const url = `${DSLD_API_BASE_URL}/search-filter?q=${finalEncodedUpc}`;
-  
+  const key = Deno.env.get("DSLD_API_KEY");
+  if (!key) return null;
+  const url = `${DSLD_URL}?q="${encodeURIComponent(upc)}"`;
   try {
-    console.log("Key present in DSLD fetch:", !!dSldApiKey);
-    console.log(`Fetching DSLD URL: ${url}`);
-    const response = await fetch(url, {
-      headers: {
-        // FIX 2: Changed 'x-api-key' to 'X-Api-Key' for consistency with working curl
-        'X-Api-Key': dSldApiKey,
-        'Content-Type': 'application/json', // Though not always strictly needed for GET, good practice
-        'User-Agent': 'Supproo/0.1 (+https://supproo.com)',
-      }
+    const res = await fetch(url, {
+      headers: { "X-Api-Key": key, "Content-Type": "application/json" }
     });
-
-    if (!response.ok) {
-      console.error(`DSLD API error! Status: ${response.status}, Text: ${await response.text()}`);
-      return null;
-    }
-    const data: any = await response.json(); // Use 'any' for now, as full DSLD response structure isn't known
-    console.log("DSLD raw response for UPC:", JSON.stringify(data, null, 2));
-
-    // FIX 3: Corrected JSON parsing to look for 'hits' array within the object response
-    if (data.hits && Array.isArray(data.hits) && data.hits.length > 0) {
-      const label = data.hits[0]._source; // Access the _source object within the hit
-
-      // Map DSLD data to SupplementData. This mapping is speculative and might need adjustment
-      // once you see actual DSLD JSON responses for a given UPC.
-      return {
-        product_id: upc, // Use the provided UPC as the product_id
-        product_name: label.productName ?? label.brandName ?? `DSLD Product (${upc})`, // Prioritize specific product name, fallback to brand or generic
-        ingredients: label.ingredientsList ?? label.ingredients ?? [], // Common names for ingredient lists
-        brand: label.brandName ?? "Unknown",
-        label_claims: label.claims ?? [],
-        certifications: label.certifications ?? [],
-        warnings: label.warnings ?? [],
-        reviews: { positive: 0, negative: 0 } // Placeholder, DSLD doesn't provide reviews directly
-      };
-    }
-
-    return null; // No data found in DSLD
-
-  } catch (error) {
-    console.error("Error fetching from DSLD:", error);
+    if (!res.ok) return null;
+    const data = await res.json();
+    const hit = data.hits?.[0]?._source;
+    if (!hit) return null;
+    const ingredients = Array.isArray(hit.ingredientsList)
+      ? hit.ingredientsList.map((n: string) => ({ name: n } as Ingredient))
+      : [];
+    return {
+      product_id: upc,
+      brand: hit.brandName ?? "",
+      product_name: hit.productName ?? hit.brandName ?? upc,
+      ingredients,
+      label_claims: hit.claims ?? [],
+      certifications: hit.certifications ?? [],
+      warnings: hit.warnings ?? [],
+      reviews: { positive: 0, negative: 0 },
+    };
+  } catch {
     return null;
   }
 }
 
 async function fetchFromFatSecret(upc: string): Promise<SupplementData | null> {
-  const token = await getFSAccessToken();
-  const url = `https://platform.fatsecret.com/rest/server.api?method=barcode.v2.search&barcode=${upc}&format=json`;
-  const r = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-  if (!r.ok) return null;
-  const j = await r.json();
-  const foods = j.barcode?.foods;
-  if (!foods?.length) return null;
-  const f = foods[0];
-  return {
-    product_id: upc,
-    product_name: f.brand_name ? `${f.brand_name} ${f.food_name}` : f.food_name,
-    brand: f.brand_name || "",
-    ingredients: typeof f.food_description === "string" ? [{name: f.food_description}] : [],
-    label_claims: [],
-    certifications: [],
-    warnings: [],
-    reviews: { positive: 0, negative: 0 },
-  };
+  try {
+    const token = await getFSAccessToken();
+    const url = `https://platform.fatsecret.com/rest/server.api?method=food.find&id_type=upc&search_expression=${upc}`;
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    if (!res.ok) return null;
+    const xml = await res.text();
+    // Supabase's edge-runtime already has DOMParser globally – no extra import needed
+    const doc = new DOMParser().parseFromString(xml, "application/xml");
+    const food = doc.querySelector("food");
+    if (!food) return null;
+    const name = food.querySelector("food_name")?.textContent ?? "";
+    const brand = food.querySelector("brand_name")?.textContent ?? "";
+    const ing = food.querySelector("ingredients")?.textContent ?? "";
+    const ingredients = ing.split(/,|;/).map((s) => s.trim()).filter(Boolean).map((n) => ({ name: n }));
+    return {
+      product_id: upc,
+      brand,
+      product_name: brand ? `${brand} ${name}` : name,
+      ingredients,
+      label_claims: [],
+      certifications: [],
+      warnings: [],
+      reviews: { positive: 0, negative: 0 },
+    };
+  } catch {
+    return null;
+  }
 }
 
-serve(async (req: Request) => {
-  // Accept both GET and POST for testing
-  const url = new URL(req.url);
-  const upc = url.searchParams.get("upc") ||
-    (req.method === "POST" ? (await req.json()).upc : undefined);
+async function fetchFromOpenFoodFacts(upc: string): Promise<SupplementData | null> {
+  try {
+    const url = `https://world.openfoodfacts.org/api/v2/product/${upc}.json`;
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (data.status !== 1) return null;
+    const p = data.product;
+    const ingredients: Ingredient[] = [];
+    if (Array.isArray(p.ingredients)) {
+      for (const i of p.ingredients) {
+        if (i.text) ingredients.push({ name: i.text });
+      }
+    } else if (p.ingredients_text) {
+      ingredients.push({ name: p.ingredients_text });
+    }
+    return {
+      product_id: p.code ?? upc,
+      brand: p.brands ?? "",
+      product_name: p.product_name ?? "Unknown",
+      ingredients,
+      label_claims: [],
+      certifications: [],
+      warnings: [],
+      reviews: { positive: 0, negative: 0 },
+    };
+  } catch {
+    return null;
+  }
+}
 
+serve(async (req) => {
+  const upc = new URL(req.url).searchParams.get("upc");
   if (!upc) {
-    return new Response(JSON.stringify({ error: "No UPC provided" }), {
-      headers: { "Content-Type": "application/json" },
+    return new Response(JSON.stringify({ error: "missing upc" }), {
       status: 400,
+      headers: { "Content-Type": "application/json" },
     });
   }
 
-  // Attempt to fetch data from DSLD first
+  console.log("Trying DSLD for", upc);
+  let sourceUsed = "";
   let data = await fetchFromDSLD(upc);
-
-  // If DSLD doesn't return data, fallback to OpenFoodFacts
+  if (data) {
+    sourceUsed = "DSLD";
+  } else {
+    console.log("DSLD failed, trying FatSecret");
+    data = await fetchFromFatSecret(upc);
+    if (data) {
+      sourceUsed = "FatSecret";
+    }
+  }
   if (!data) {
-    console.log("Falling back to OpenFoodFacts for UPC:", upc);
+    console.log("FatSecret failed, trying OpenFoodFacts");
     data = await fetchFromOpenFoodFacts(upc);
+    if (data) {
+      sourceUsed = "OpenFoodFacts";
+    }
   }
 
-  const fat = await fetchFromFatSecret(upc);
-  if (fat) {
-    console.log("Data found from FatSecret.");
-    return new Response(JSON.stringify(fat), { headers: { "Content-Type": "application/json" }, status: 200 });
-  }
- 
   if (!data) {
-    return new Response(
-      JSON.stringify({
-        error: `UPC '${upc}' not found or failed to fetch data from DSLD, OpenFoodFacts, and FatSecret.`,
-      }),
-      {
-        headers: { "Content-Type": "application/json" },
-        status: 404,
-      },
-    );
+    return new Response(JSON.stringify({ error: "UPC not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
   }
- 
-  console.log("Data from DSLD, OpenFoodFacts, or FatSecret:", JSON.stringify(data, null, 2));
+  console.log("Resolved via", sourceUsed);
   return new Response(JSON.stringify(data), {
     headers: { "Content-Type": "application/json" },
   });

--- a/supabase/functions/score-supplement/index.ts
+++ b/supabase/functions/score-supplement/index.ts
@@ -1,120 +1,45 @@
 /// <reference lib="deno.ns" />
-// deno-lint-ignore-file no-explicit-any
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import type { SupplementData, SimplifiedAIResponse, FullSupplementScoreResponse } from "../../_shared/types.ts";
 
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
-
-// ---------- types ----------
-interface Ingredient { name: string; dosage?: string; form?: string }
-interface SupplementData {
-  product_id: string; ingredients: Ingredient[]; brand: string; product_name: string;
-  label_claims?: string[]; certifications?: string[]; warnings?: string[];
-  reviews?: { positive: number; negative: number }
-}
-
-// Simplified AI Response Interface
-interface SimplifiedAIResponse {
-  pid: string; // product_id
-  t: number;   // Transparency / Label Honesty (0-10)
-  dose: number; // Clinical Dosing & Bioavailability (0-10)
-  qual: number; // Quality & Certifications (0-10)
-  risk: number; // Additives & Brand Risk (0-10)
-  highlights: string[]; // 1-3 concise findings (max 80 chars each)
-}
-
-// Full SupplementScoreResponse (for later backend expansion, not directly used in AI response yet)
-interface ScoreBreakdownDetail { score: number; reasons: string[]; weight: number }
-interface SupplementScoreBreakdown {
-  ingredient_transparency: ScoreBreakdownDetail; clinical_doses: ScoreBreakdownDetail;
-  bioavailability: ScoreBreakdownDetail; third_party_testing: ScoreBreakdownDetail;
-  additives_fillers: ScoreBreakdownDetail; label_accuracy: ScoreBreakdownDetail;
-  manufacturing_standards: ScoreBreakdownDetail; brand_history: ScoreBreakdownDetail;
-  consumer_sentiment: ScoreBreakdownDetail;
-}
-interface OverallAssessment {
-  strengths: string[]; weaknesses: string[]; recommendations: string[];
-  safety_rating: string; efficacy_rating: string; transparency_rating: string;
-}
-interface Source { type: string; source: string; url: string; relevance: string }
-interface FullSupplementScoreResponse {
-  product_id: string;
-  product_name: string; // Add this line
-  final_score: number; score_breakdown: SupplementScoreBreakdown;
-  overall_assessment: OverallAssessment; sources: Source[]; timestamp: string;
-  confidence_score: number; error?: string;
-}
-
-
-// ---------- helpers ----------
-function clampScore(score: number, min: number, max: number): number {
-  return Math.max(min, Math.min(score, max));
-}
-
-// NEW ROBUST JSON EXTRACTOR
-function extractJson(raw: string): any | null {
-  // 1. Try direct parse first (most common and efficient for clean JSON)
-  try { return JSON.parse(raw); } catch (e) { /* console.log("Direct parse failed:", e.message); */ }
-
-  // 2. Try greedy match for JSON object possibly wrapped in other text (e.g., "Here's the JSON: {...}")
-  // [\s\S]* matches any character including newlines
-  const greedy = raw.match(/{[\s\S]*}/);
-  if (greedy) {
-    try {
-      return JSON.parse(greedy[0]);
-    } catch (e) {
-      // console.log("Greedy parse failed:", e.message);
-    }
-  }
-
-  // 3. Try a simpler, single-level match if the greedy failed (e.g., for very short, non-nested JSON)
-  const simple = raw.match(/({[^{}]*})/); // Matches first { ... } without nested braces
-  if (simple) {
-    try {
-      return JSON.parse(simple[0]);
-    } catch (e) {
-      // console.log("Simple parse failed:", e.message);
-    }
-  }
-
-  // If all attempts fail, log error and return null
-  console.error("extractJson failed to find valid JSON. Raw head:", raw.slice(0,200));
-  return null;
-}
-function expandToFull(r: SimplifiedAIResponse): FullSupplementScoreResponse {
+function expandToFull(
+  r: SimplifiedAIResponse,
+  productName: string,
+): FullSupplementScoreResponse {
   const map = {
     ingredient_transparency: r.t,
-    label_accuracy:         r.t,
-    clinical_doses:         r.dose,
-    bioavailability:        r.dose,
-    third_party_testing:    r.qual,
-    manufacturing_standards:r.qual,
-    additives_fillers:      r.risk,
-    brand_history:          r.risk,
-    consumer_sentiment:     r.risk,
-  };
+    label_accuracy: r.t,
+    clinical_doses: r.dose,
+    bioavailability: r.dose,
+    third_party_testing: r.qual,
+    manufacturing_standards: r.qual,
+    additives_fillers: r.risk,
+    brand_history: r.risk,
+    consumer_sentiment: r.risk,
+  } as const;
 
-  const weights = {
+  const weights: Record<keyof typeof map, number> = {
     ingredient_transparency: 0.20,
-    clinical_doses:          0.15,
-    bioavailability:         0.10,
-    third_party_testing:     0.15,
-    additives_fillers:       0.10,
-    label_accuracy:          0.10,
+    clinical_doses: 0.15,
+    bioavailability: 0.10,
+    third_party_testing: 0.15,
+    additives_fillers: 0.10,
+    label_accuracy: 0.10,
     manufacturing_standards: 0.10,
-    brand_history:           0.05,
-    consumer_sentiment:      0.05,
+    brand_history: 0.05,
+    consumer_sentiment: 0.05,
   };
 
   let final = 0;
-  for (const k in map) final += map[k] * weights[k] * 10; // 0-10 → 0-100
+  for (const k in map) final += (map as any)[k] * weights[k as keyof typeof map] * 10;
 
   return {
     product_id: r.pid,
+    product_name: productName,
     final_score: Math.round(final),
     score_breakdown: Object.fromEntries(
-      Object.entries(map).map(([k, v]) => [
-        k, { score: v, reasons: [], weight: weights[k] * 100 },
-      ]),
+      Object.entries(map).map(([k, v]) => [k, { score: v, reasons: [], weight: weights[k as keyof typeof map] * 100 }])
     ) as any,
     overall_assessment: {
       strengths: r.highlights.slice(0, 1),
@@ -130,216 +55,41 @@ function expandToFull(r: SimplifiedAIResponse): FullSupplementScoreResponse {
   };
 }
 
-
-// ---------- core ----------
-async function scoreSupplement(supplementData: SupplementData): Promise<SimplifiedAIResponse> {
-  console.log("SupplementData received:", JSON.stringify(supplementData, null, 2));
-  const apiKey = Deno.env.get('EXPO_PUBLIC_OPENROUTER_API_KEY');
-  if (!apiKey) throw new Error('OpenRouter API key not set');
-
-  // UPDATED: Lean Prompt with clarified highlights rule (from previous step)
-  const prompt = `
-You are SupplementScoreAI. Return ONLY minified JSON.
-Strictly adhere to this simplified JSON output format:
-{ "pid": "product_id_value", "t": 0-10, "dose": 0-10, "qual": 0-10, "risk": 0-10, "highlights": ["bullet 1", "bullet 2"] }
-
-Rules:
-• Score each pillar (t, dose, qual, risk) from 0 to 10.
-    - 't': Transparency / Label Honesty
-    - 'dose': Clinical Dosing & Bioavailability
-    - 'qual': Quality & Certifications
-    - 'risk': Additives & Brand Risk
-• "highlights" must be a minified JSON array of 1 to 3 concise findings (max 80 chars each) about the product.
-• If uncertain for a score, default to 0 and note reason in highlights if applicable.
-
-DATA:
-${JSON.stringify(supplementData)}
-`;
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 25000); // 25-second timeout for the AI request
-
-  let res: Response; // Declare 'res' here so it's accessible in the catch block if res.json() fails
-  let aiRaw: string = ''; // Initialize aiRaw to be available for error logging
-
-  try {
-    res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        model: 'openai/gpt-4o-mini',
-        temperature: 0,
-        top_p: 0.1,
-        max_tokens: 2000,
-        response_format: { type: 'json_object' },
-        messages: [{ role: 'user', content: prompt }]
-      }),
-      signal: controller.signal
-    });
-    clearTimeout(timeout);
-
-    if (!res.ok) {
-        // Attach original response to error for detailed logging in handler
-        const error = new Error(`OpenRouter request failed with status ${res.status}: ${await res.text()}`);
-        (error as any).status = res.status;
-        (error as any).res = res; // Attach the response object
-        throw error;
-    }
-
-    const data = await res.json();
-    aiRaw = data?.choices?.[0]?.message?.content ?? '';
-
-    // NEW LOGGING (as per "other, other AI" suggestion): To definitively check for truncation and content
-    console.log("raw len:", aiRaw.length);
-    console.log("head:", aiRaw.slice(0,500));
-    console.log("tail:", aiRaw.slice(-500));
-
-
-    const parsed = extractJson(aiRaw); // Use the new robust extractor
-
-    // Early empty-object guard (adapted from "other, other AI" suggestion)
-    if (!parsed || Object.keys(parsed).length === 0) {
-      console.error("✖ empty/invalid JSON. raw len:", aiRaw.length);
-      const error = new Error("AI returned empty or invalid JSON structure.");
-      (error as any).status = 502;
-      (error as any).rawResponse = aiRaw; // Attach the raw AI response text for full context
-      throw error;
-    }
-    return parsed as SimplifiedAIResponse;
-
-  } catch (err) {
-    if (err instanceof DOMException && err.name === 'AbortError') {
-      const error = new Error('OpenRouter request timed out after 25 seconds.');
-      (error as any).status = 504;
-      throw error;
-    }
-    // Re-throw the error for the handler to catch with its improved logging
-    throw err;
-  }
+async function score(data: SupplementData, scraped: string | null): Promise<SimplifiedAIResponse> {
+  const key = Deno.env.get("EXPO_PUBLIC_OPENROUTER_API_KEY");
+  if (!key) throw new Error("OpenRouter API key missing");
+  const prompt = `You are SupplementScoreAI. Using the provided data and optional scraped text, score the product. Return ONLY minified JSON with keys pid,t,dose,qual,risk,highlights.\nDATA:${JSON.stringify(data)}\nSCRAPED:${scraped ?? "NONE"}`;
+  const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: "openai/gpt-4o-mini",
+      temperature: 0,
+      response_format: { type: "json_object" },
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+  if (!res.ok) throw new Error(`OpenRouter error ${res.status}`);
+  const j = await res.json();
+  const txt = j.choices?.[0]?.message?.content ?? "";
+  return JSON.parse(txt) as SimplifiedAIResponse;
 }
 
-// ---------- handler ----------
-async function handler(req: Request): Promise<Response> {
-  if (req.method !== 'POST') {
-    return new Response('Method not allowed', { status: 405 });
-  }
-
+serve(async (req) => {
+  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
   try {
+    const { data, scraped }: { data: SupplementData; scraped: string | null } = await req.json();
+    const simple = await score(data, scraped);
+    const full = expandToFull(simple, data.product_name);
+
     const supabase = createClient(
-      Deno.env.get('EXPO_PUBLIC_SUPABASE_URL')!,
-      Deno.env.get('EXPO_PUBLIC_SUPABASE_ANON_KEY')!
+      Deno.env.get("EXPO_PUBLIC_SUPABASE_URL")!,
+      Deno.env.get("EXPO_PUBLIC_SUPABASE_ANON_KEY")!,
     );
-
-    const incoming: SupplementData = await req.json();
-    const scoreResp = await scoreSupplement(incoming);
-    const fullScoreResp: FullSupplementScoreResponse = {
-     ...expandToFull(scoreResp),
-     product_name: incoming.product_name,
-   };
-
-    const { error } = await supabase
-      .from('scored_products')
-      .upsert([fullScoreResp], { onConflict: ['product_id'] });
-
-    if (error) {
-      console.error('Supabase upsert error:', error);
-      throw new Error(`DB upsert failed: ${error.message}`);
-    }
-
-    // TODO: Phase 2 - Implement the backend "Rubric Expander" here
-    // const responseToStore = {
-    //   product_id: scoreResp.pid,
-    //   lean_score_t: scoreResp.t,
-    //   lean_score_dose: scoreResp.dose,
-    //   lean_score_qual: scoreResp.qual,
-    //   lean_score_risk: scoreResp.risk,
-    //   lean_highlights: scoreResp.highlights,
-    //   timestamp: new Date().toISOString(),
-    // };
-
-    // const { error: simplifiedError } = await supabase
-    //   .from('simplified_scored_products_test')
-    //   .upsert([responseToStore], { onConflict: ['product_id'] });
-
-    // if (simplifiedError) {
-    //   console.error('Supabase upsert error:', simplifiedError);
-    //   throw new Error(`DB upsert failed: ${simplifiedError.message}`);
-    // }
-
-    return new Response(JSON.stringify(fullScoreResp), {
-      headers: { 'Content-Type': 'application/json' },
-    });
-  } catch (err: any) {
-    // UPDATED: Full debug on error (as per "other, other AI" suggestion)
-    let fullResponseText = 'N/A';
-    let responseStatus: string | number = 'N/A';
-    let responseHeaders = {};
-
-    if (err instanceof Error && (err as any).res instanceof Response) {
-      // If the error originated from the OpenRouter fetch (res.ok check)
-      const originalRes = (err as any).res;
-      responseStatus = originalRes.status;
-      responseHeaders = Object.fromEntries([...originalRes.headers]);
-      try {
-        fullResponseText = await originalRes.clone().text(); // Use .clone() to re-read body
-      } catch (cloneErr) {
-        fullResponseText = `Error cloning/reading response body for logging: ${cloneErr}`;
-      }
-    } else if (err && typeof err === 'object' && 'rawResponse' in err) {
-      // If the error was thrown internally from scoreSupplement (e.g., parsing error)
-      fullResponseText = err.rawResponse;
-    }
-
-    let errorMessage = 'An unknown error occurred.';
-    let errorDetails = 'No specific details available.';
-    let statusCode = 500;
-
-    if (err instanceof Error) {
-      errorMessage = err.message;
-      errorDetails = err.message;
-      if (err.stack) {
-        errorDetails = err.stack;
-      }
-      if ((err as any).status) {
-        statusCode = (err as any).status;
-      }
-    } else if (typeof err === 'string') {
-      errorMessage = err;
-      errorDetails = err;
-    } else if (err && typeof err === 'object' && 'message' in err) {
-      errorMessage = (err as any).message;
-      errorDetails = JSON.stringify(err);
-      if ((err as any).status) {
-        statusCode = (err as any).status;
-      }
-    }
-    if (!err) {
-      errorMessage = 'An unexpected null/undefined error was caught.';
-      errorDetails = 'The error object itself was null or undefined.';
-    }
-
-    // Console.error for full context
-    console.error('❗ Error details:', {
-      errorMessage,
-      errorDetails,
-      statusCode,
-      fullResponseFromAI_length: fullResponseText.length,
-      fullResponseFromAI_head: fullResponseText.slice(0, 500),
-      fullResponseFromAI_tail: fullResponseText.slice(-500),
-      aiResponseStatus: responseStatus,
-      aiResponseHeaders: responseHeaders,
-      originalError: err, // Log the raw error object too
-    });
-
-    return new Response(JSON.stringify({ error: errorMessage, details: errorDetails }), {
-      status: statusCode,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    await supabase.from("scored_products").upsert([full], { onConflict: "product_id" });
+    return new Response(JSON.stringify(full), { headers: { "Content-Type": "application/json" } });
+  } catch (err) {
+    console.error(err);
+    return new Response(JSON.stringify({ error: String(err) }), { status: 500, headers: { "Content-Type": "application/json" } });
   }
-}
-
-// ---------- boot ----------
-serve(handler);
+});


### PR DESCRIPTION
## Summary
- add shared types for supplement scoring
- replace `resolve-upc` edge function with DSLD/FatSecret/OpenFoodFacts lookup
- replace `score-supplement` to accept scraped text and upsert results
- add orchestrator `full-score-from-upc`
- small cleanup for resolve-upc and score-supplement

## Testing
- `npm run lint` *(fails: expo not found)*


------
https://chatgpt.com/codex/tasks/task_e_684b536c89a48321bac76274f05e8bc7